### PR TITLE
Update explainer to address API discussions

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -21,7 +21,7 @@
 MD007:
   indent: 2                   # Unordered list indentation
 MD013:
-  line_length: 100            # Line length 80 is far to short
+  line_length: 200            # Line length 80 is far to short
 MD024:
   siblings_only: true         # Multiple headings with the same content
 MD026:

--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -1,0 +1,10 @@
+{
+  "filters": {
+    "comments": true
+  },
+  "rules": {
+    "terminology": {
+      "severity": "warning"
+    }
+  }
+}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,5 +30,9 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_HTML: true
+          VALIDATE_JSON: true
+          VALIDATE_MARKDOWN: true
+          VALIDATE_NATURAL_LANGUAGE: true
           DEFAULT_BRANCH: "main"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ From the point of view of the developer the exact beacon send time is unknown.
 ### JavaScript API
 
  In detail, the proposed design includes a new interface [`PendingBeacon`](#pendingbeacon),
- and two of its implementations [`PendingGETBeacon`](#pendinggetbeacon) and [`PendingPOSTBeacon`](#pendingpostbeacon):
+ and two of its implementations [`PendingGetBeacon`](#pendinggetbeacon) and [`PendingPostBeacon`](#pendingpostbeacon):
 
 ---
 
@@ -84,7 +84,7 @@ From the point of view of the developer the exact beacon send time is unknown.
 
 `PendingBeacon` defines the common properties & methods representing a beacon.
 However, it should not be constructed directly.
-Use [`PendingGETBeacon`](#pendinggetbeacon) or [`PendingPOSTBeacon`](#pendingpostbeacon) instead.
+Use [`PendingGetBeacon`](#pendinggetbeacon) or [`PendingPostBeacon`](#pendingpostbeacon) instead.
 
 ##### Properties
 
@@ -123,23 +123,24 @@ The `PendingBeacon` class define the following methods:
 
 ---
 
-#### `PendingGETBeacon`
+#### `PendingGetBeacon`
 
-The `PendingGETBeacon` class provides additional methods for manipulating a beacon's GET request data.
+The `PendingGetBeacon` class provides additional methods for manipulating a beacon's GET request data.
 
 ##### Constructor
 
 ```js
-beacon = new PendingGETBeacon(url, options = {});
+beacon = new PendingGetBeacon(url, options = {});
 ```
 
-An instance of `PendingGETBeacon` represents a beacon that will be sent by the browser at some point in the future.
+An instance of `PendingGetBeacon` represents a `GET` beacon that will be sent by the browser at some point in the future.
 Calling this constructor queues the beacon for sending by the browser;
-even if the result goes out of scope, the beacon will still be sent (unless `deactivate()`-ed beforehand).
+even if the result goes out of scope,
+the beacon will still be sent (unless `deactivate()`-ed beforehand).
 
 The `url` parameter is a string that specifies the value of the `url` property.
 It works the same as the existing [`Navigator.sendBeacon`][sendBeacon-api]’s `url` parameter does.
-Note that multiple instances of `PendingGETBeacon` can be made, so multiple beacons can be sent to multiple url endpoints.
+Calling the constructor with `url`=`null`/`undefined` will result in an exception.
 
 The `options` parameter would be a dictionary that optionally allows specifying the following properties for the beacon:
 
@@ -148,36 +149,38 @@ The `options` parameter would be a dictionary that optionally allows specifying 
 
 ##### Properties
 
-The `PendingGETBeacon` class would support [the same properties](#properties) inheriting from
+The `PendingGetBeacon` class would support [the same properties](#properties) inheriting from
 `PendingBeacon`'s, except with the following differences:
 
 * `method`: Its value is set to `'GET'`.
 
 ##### Methods
 
-The `PendingGETBeacon` class would support the following additional methods:
+The `PendingGetBeacon` class would support the following additional methods:
 
 * `setURL(url)`: Set the current beacon's `url` property. The `url` parameter takes a `String`.
 
 ---
 
-#### `PendingPOSTBeacon`
+#### `PendingPostBeacon`
 
-The `PendingPOSTBeacon` class provides additional methods for manipulating a beacon's POST request data even after constructed.
+The `PendingPostBeacon` class provides additional methods for manipulating a beacon's POST request data.
 
 ##### Constructor
 
 ```js
-beacon = new PendingPOSTBeacon(url, options = {});
+beacon = new PendingPostBeacon(url, options = {});
 ```
 
-An instance of `PendingPOSTBeacon` represents a beacon that will be sent by the browser at some point in the future.
-Calling this constructor queues the beacon for sending by the browser;
-even if the result goes out of scope, the beacon will still be sent (unless `deactivate()`-ed beforehand).
+An instance of `PendingPostBeacon` represents a `POST` beacon.
+Simply calling this constructor will **not** queue the beacon for sending.
+Instead, a `POST` beacon will **only be queued** by the browser for sending at some point in the future if it has non-`undefined` and non-`null` data.
+After it is queued, even if the instance goes out of scope,
+the beacon will still be sent (unless `deactivate()`-ed beforehand).
 
 The `url` parameter is a string that specifies the value of the `url` property.
 It works the same as the existing [`Navigator.sendBeacon`][sendBeacon-api]’s `url` parameter does.
-Note that multiple instances of `PendingPOSTBeacon` can be made, so multiple beacons can be sent to multiple url endpoints.
+Calling the constructor with `url`=`null`/`undefined` will result in an exception.
 
 The `options` parameter would be a dictionary that optionally allows specifying the following properties for the beacon:
 
@@ -186,20 +189,23 @@ The `options` parameter would be a dictionary that optionally allows specifying 
 
 ##### Properties
 
-The `PendingPOSTBeacon` class would support [the same properties](#properties) inheriting from
+The `PendingPostBeacon` class would support [the same properties](#properties) inheriting from
 `PendingBeacon`'s, except with the following differences:
 
 * `method`: Its value is set to `'POST'`.
+* `timeout`: The timer only starts after its value is set or updated **and** `setData(data)` has ever been called with non-`null` and non-`undefined` data.
 
 ##### Methods
 
-The `PendingPOSTBeacon` class would support the following additional methods:
+The `PendingPostBeacon` class would support the following additional methods:
 
 * `setData(data)`: Set the current beacon data.
   The `data` parameter would take the same types as the [sendBeacon][sendBeacon-w3] method’s `data` parameter.
   That is, one of [`ArrayBuffer`][ArrayBuffer-api],
   [`ArrayBufferView`][ArrayBufferView-api], [`Blob`][Blob-api], `String`,
   [`FormData`][FormData-api], or [`URLSearchParams`][URLSearchParams-api].
+  If `data` is not `undefined` and not `null`, the browser will queue the beacon for sending,
+  which means it kicks off the timer for `timeout` property (if set) and the timer for `backgroundTimeout` property.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 Authors: [Darren Willis](https://github.com/darrenw), [Fergal Daly](https://github.com/fergald), [Ming-Ying Chung](https://github.com/mingyc) - Google
 
+[![GitHub Super-Linter](https://github.com/WICG/unload-beacon/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+
 This document is an explainer for a system for sending beacons when pages are discarded,
 that uses a stateful API rather than having developers explicitly send beacons themselves.
 
 ## Problem And Motivation
 
 Web developers have a need for *‘beaconing’* -
-that is, sending a bundle of data to a backend server, without expecting a particular response, ideally at the ‘end’ of a user’s visit to a page.
+that is, sending a bundle of data to a backend server, without expecting a particular response,
+ideally at the ‘end’ of a user’s visit to a page.
 There are currently
 [four major methods](https://calendar.perfplanet.com/2020/beaconing-in-practice/) of beaconing used around the web:
 
@@ -360,7 +363,7 @@ and simple to use.
 Has `appendData(data)` which appends new data to the beacon's payload.
 The beacon will flush queued payload according to the timeouts and the browser state.
 
-The use-case is for continuously logging events that are accumulated on the server side.
+The use-case is for continuously logging events that are accumulated on the server-side.
 
 #### ReplaceableBeacon
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ the beacon will still be sent (unless `deactivate()`-ed beforehand).
 
 The `url` parameter is a string that specifies the value of the `url` property.
 It works the same as the existing [`Navigator.sendBeacon`][sendBeacon-api]’s `url` parameter does.
-Calling the constructor with `url`=`null`/`undefined` will result in an exception.
 
 The `options` parameter would be a dictionary that optionally allows specifying the following properties for the beacon:
 
@@ -183,7 +182,6 @@ the beacon will still be sent (unless `deactivate()`-ed beforehand).
 
 The `url` parameter is a string that specifies the value of the `url` property.
 It works the same as the existing [`Navigator.sendBeacon`][sendBeacon-api]’s `url` parameter does.
-Calling the constructor with `url`=`null`/`undefined` will result in an exception.
 
 The `options` parameter would be a dictionary that optionally allows specifying the following properties for the beacon:
 
@@ -208,7 +206,7 @@ The `PendingPostBeacon` class would support the following additional methods:
   [`ArrayBufferView`][ArrayBufferView-api], [`Blob`][Blob-api], `String`,
   [`FormData`][FormData-api], or [`URLSearchParams`][URLSearchParams-api].
   If `data` is not `undefined` and not `null`, the browser will queue the beacon for sending,
-  which means it kicks off the timer for `timeout` property (if set) and the timer for `backgroundTimeout` property.
+  which means it kicks off the timer for `timeout` property (if set) and the timer for `backgroundTimeout` property (after the page enters `hidden` state).
 
 ---
 
@@ -363,7 +361,7 @@ and simple to use.
 Has `appendData(data)` which appends new data to the beacon's payload.
 The beacon will flush queued payload according to the timeouts and the browser state.
 
-The use-case is for continuously logging events that are accumulated on the server-side.
+The use-case is for continuously logging events that are accumulated on the server side.
 
 #### ReplaceableBeacon
 


### PR DESCRIPTION
- Update #6: Renamed `PendingPOSTBeacon` with `PendingPostBeacon`, and same
  for `PendingGetBeacon`, as it looks like [TAG Design Principles][1] only
  suggests Initialisms for abbreviations, and POST/GET are not abbrs.
- Fix #17
  - Make `PendingPostBeacon` only be queued when its data is non-`null`
    and non-`undefined`. Also update its `timeout` property's behavior.

[1]: https://www.w3.org/TR/design-principles/#casing-rules